### PR TITLE
Escape and unescape commas and parentheses in strings in lists.

### DIFF
--- a/tests/ob-raku-tests.org
+++ b/tests/ob-raku-tests.org
@@ -25,6 +25,11 @@ say 7;
    #+BEGIN_SRC raku
 my @a = (("Name", "Age", "Weight"), "HLINE", ("Fido", 4, 6));
    #+END_SRC
+   
+   #+NAME: list-breaking-string-test
+   #+BEGIN_SRC raku
+my @a = ("This, is(", ",)a, test")
+   #+END_SRC
 
 ** Raku source block returning a hash
 


### PR DESCRIPTION
This is a silly workaround and may break other things, but for now
it's fine.

Fixes #1 